### PR TITLE
fix wrapping of log messages

### DIFF
--- a/fellow/SRC/C/FELLOW.C
+++ b/fellow/SRC/C/FELLOW.C
@@ -172,25 +172,41 @@ static void fellowLogDateTime(void)
   fellowAddLog2(tmp);
 }
 
-void fellowAddLog(const char *format,...)
+void fellowAddLog(const char *format, ...)
 {
   char buffer[WRITE_LOG_BUF_SIZE];
+  char *buffer2 = NULL;
   va_list parms;
   int count = 0;
 
-  va_start (parms, format);
-  count = _vsnprintf( buffer, WRITE_LOG_BUF_SIZE-1, format, parms );
+  if (fellow_newlogline)
+  {
+    // log date/time into buffer
+    time_t thetime;
+    struct tm *timedata;
 
-  if(fellow_newlogline)
-    fellowLogDateTime();
+    thetime = time(NULL);
+    timedata = localtime(&thetime);
+    strftime(buffer, 255, "%c: ", timedata);
+    // move buffer pointer ahead to log additional text after date/time
+    buffer2 = buffer + strlen(buffer);
+  }
+  else
+  {
+    // skip date/time, log to beginning of buffer
+    buffer2 = buffer;
+  }
+
+  va_start(parms, format);
+  count = _vsnprintf(buffer2, WRITE_LOG_BUF_SIZE - 1 - strlen(buffer), format, parms);
 
   fellowAddLog2(buffer);
 
-  if(buffer[strlen(buffer)-1] == '\n')
+  if (buffer[strlen(buffer) - 1] == '\n')
     fellow_newlogline = TRUE;
   else
     fellow_newlogline = FALSE;
-  va_end (parms);
+  va_end(parms);
 }
 
 void fellowAddLogRequester(FELLOW_REQUESTER_TYPE type, const char *format, ...)

--- a/fellow/SRC/WIN32/C/JOYDRV.C
+++ b/fellow/SRC/WIN32/C/JOYDRV.C
@@ -216,7 +216,7 @@ void joyDrvDInputSetCooperativeLevel(int port)
   res = IDirectInputDevice8_SetCooperativeLevel(joy_drv_lpDID[port], gfxDrvCommon->GetHWND(), ((joy_drv_focus) ? DISCL_EXCLUSIVE : DISCL_NONEXCLUSIVE) | DISCL_FOREGROUND );
   if (res != DI_OK)
   {
-    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): ", res );
+    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel():", res );
   }
 
 #define INITDIPROP( diprp, obj, how ) \
@@ -232,7 +232,7 @@ void joyDrvDInputSetCooperativeLevel(int port)
   res = IDirectInputDevice8_SetProperty(joy_drv_lpDID[port], DIPROP_RANGE, &diprg.diph );
   if( res != DI_OK )
   {
-    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): SetProperty RANGE X : ", res );
+    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): SetProperty RANGE X :", res );
   }
 
   INITDIPROP( diprg, DIJOFS_Y, DIPH_BYOFFSET )
@@ -242,7 +242,7 @@ void joyDrvDInputSetCooperativeLevel(int port)
   res = IDirectInputDevice8_SetProperty(joy_drv_lpDID[port], DIPROP_RANGE, &diprg.diph );
   if( res != DI_OK ) 
   {
-    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): SetProperty RANGE Y : ", res );
+    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): SetProperty RANGE Y :", res );
   }
 
   INITDIPROP( dipdw, DIJOFS_X, DIPH_BYOFFSET )
@@ -251,7 +251,7 @@ void joyDrvDInputSetCooperativeLevel(int port)
   res = IDirectInputDevice8_SetProperty(joy_drv_lpDID[port], DIPROP_DEADZONE, &dipdw.diph );
   if( res != DI_OK ) 
   {
-    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): SetProperty DEADZONE X : ", res );
+    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): SetProperty DEADZONE X :", res );
   }
 
   INITDIPROP( dipdw, DIJOFS_Y, DIPH_BYOFFSET )
@@ -260,7 +260,7 @@ void joyDrvDInputSetCooperativeLevel(int port)
   res = IDirectInputDevice8_SetProperty(joy_drv_lpDID[port], DIPROP_DEADZONE, &dipdw.diph );
   if( res != DI_OK ) 
   {
-    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): SetProperty DEADZONE Y : ", res );
+    joyDrvDInputFailure("joyDrvDInputSetCooperativeLevel(): SetProperty DEADZONE Y :", res );
   }
 
 #undef INITDIPROP
@@ -280,7 +280,7 @@ void joyDrvDInputUnacquire(int port)
     HRESULT res = IDirectInputDevice8_Unacquire( joy_drv_lpDID[port] );
     if (res != DI_OK)
     {
-      joyDrvDInputFailure("joyDrvDInputUnacquire(): ", res);
+      joyDrvDInputFailure("joyDrvDInputUnacquire():", res);
     }
   }
 }
@@ -306,7 +306,7 @@ void joyDrvDInputAcquire(int port)
     res = IDirectInputDevice8_Acquire( joy_drv_lpDID[port] );
     if (res != DI_OK)
     {
-      joyDrvDInputFailure("joyDrvDInputAcquire(): ", res);
+      joyDrvDInputFailure("joyDrvDInputAcquire():", res);
     }
   }
 }
@@ -320,14 +320,14 @@ BOOLE joyDrvDxCreateAndInitDevice( IDirectInput8 *pDi, IDirectInputDevice8 *pDiD
     res = CoCreateInstance(CLSID_DirectInputDevice8, NULL, CLSCTX_INPROC_SERVER, IID_IDirectInputDevice8, (LPVOID*) &(pDiD[port]));
     if (res != DI_OK)
     {
-      joyDrvDInputFailure("joyDrvDInputInitialize(): DeviceCoCreateInstance() ", res );
+      joyDrvDInputFailure("joyDrvDInputInitialize(): DeviceCoCreateInstance()", res );
       return TRUE;
     }
 
     res = IDirectInputDevice8_Initialize(pDiD[port], win_drv_hInstance, DIRECTINPUT_VERSION, guid );
     if (res != DI_OK)
     {
-      joyDrvDInputFailure("joyDrvDInputInitialize(): DeviceInitialize() ", res );
+      joyDrvDInputFailure("joyDrvDInputInitialize(): DeviceInitialize()", res );
       return TRUE;
     }
   }
@@ -335,7 +335,7 @@ BOOLE joyDrvDxCreateAndInitDevice( IDirectInput8 *pDi, IDirectInputDevice8 *pDiD
   res = IDirectInputDevice8_SetDataFormat( pDiD[port], &c_dfDIJoystick );
   if (res != DI_OK)
   {
-    joyDrvDInputFailure("joyDrvDInputInitialize(): SetDataFormat() ", res );
+    joyDrvDInputFailure("joyDrvDInputInitialize(): SetDataFormat()", res );
     return TRUE;
   }
 		
@@ -379,7 +379,7 @@ void joyDrvDInputInitialize(void)
     res = CoCreateInstance(CLSID_DirectInput8, NULL, CLSCTX_INPROC_SERVER, IID_IDirectInput8, (LPVOID*) &joy_drv_lpDI);
     if (res != DI_OK)
     {
-      joyDrvDInputFailure("joyDrvDInputInitialize(): CoCreateInstance() ", res );
+      joyDrvDInputFailure("joyDrvDInputInitialize(): CoCreateInstance()", res );
       joy_drv_failed = TRUE;
       return;
     }
@@ -387,7 +387,7 @@ void joyDrvDInputInitialize(void)
     res = IDirectInput8_Initialize(joy_drv_lpDI, win_drv_hInstance, DIRECTINPUT_VERSION);
     if (res != DI_OK)
     {
-      joyDrvDInputFailure("joyDrvDInputInitialize(): Initialize() ", res );
+      joyDrvDInputFailure("joyDrvDInputInitialize(): Initialize()", res );
       joy_drv_failed = TRUE;
       return;
     }
@@ -397,7 +397,7 @@ void joyDrvDInputInitialize(void)
     res = IDirectInput8_EnumDevices(joy_drv_lpDI, DI8DEVCLASS_GAMECTRL, joyDrvInitJoystickInput, joy_drv_lpDI, DIEDFL_ATTACHEDONLY);
     if (res != DI_OK)
     {
-      joyDrvDInputFailure("joyDrvDInputInitialize(): EnumDevices() ", res );
+      joyDrvDInputFailure("joyDrvDInputInitialize(): EnumDevices()", res );
       joy_drv_failed = TRUE;
       return;
     }
@@ -494,7 +494,7 @@ BOOLE joyDrvCheckJoyMovement(int port, BOOLE *Up, BOOLE *Down, BOOLE *Left, BOOL
     {
       if (res != DI_BUFFEROVERFLOW)
       {
-	joyDrvDInputFailure( "joyDrvMovementHandler(): Poll() ", res );
+	joyDrvDInputFailure( "joyDrvMovementHandler(): Poll()", res );
       }
     }
 
@@ -505,7 +505,7 @@ BOOLE joyDrvCheckJoyMovement(int port, BOOLE *Up, BOOLE *Down, BOOLE *Left, BOOL
 
       if( LostCounter-- < 0 )
       {
-	joyDrvDInputFailure("joyDrvMovementHandler(): abort -- ", res );
+	joyDrvDInputFailure("joyDrvMovementHandler(): abort --", res );
 	joy_drv_failed = TRUE;
 	return TRUE;
       }
@@ -514,7 +514,7 @@ BOOLE joyDrvCheckJoyMovement(int port, BOOLE *Up, BOOLE *Down, BOOLE *Left, BOOL
   
   if (res != DI_OK)
   {
-    joyDrvDInputFailure("joyDrvMovementHandler(): GetDeviceState() ", res );
+    joyDrvDInputFailure("joyDrvMovementHandler(): GetDeviceState()", res );
     return TRUE;
   }
 

--- a/fellow/SRC/WIN32/C/KBDDRV.C
+++ b/fellow/SRC/WIN32/C/KBDDRV.C
@@ -657,9 +657,7 @@ STR *kbdDrvDInputErrorString(HRESULT hResult)
 
 void kbdDrvDInputFailure(STR *header, HRESULT err)
 {
-  fellowAddLog(header);
-  fellowAddLog(kbdDrvDInputErrorString(err));
-  fellowAddLog("\n");
+  fellowAddLog("%s %s\n", header, kbdDrvDInputErrorString(err));
 }
 
 
@@ -672,7 +670,7 @@ bool kbdDrvDInputSetCooperativeLevel(void)
   HRESULT res = IDirectInputDevice_SetCooperativeLevel(kbd_drv_lpDID, gfxDrvCommon->GetHWND(), DISCL_EXCLUSIVE | DISCL_FOREGROUND);
   if (res != DI_OK)
   {
-    kbdDrvDInputFailure("kbdDrvDInputSetCooperativeLevel(): ", res );
+    kbdDrvDInputFailure("kbdDrvDInputSetCooperativeLevel():", res );
     return false;
   }
   return true;
@@ -728,7 +726,7 @@ void kbdDrvDInputUnacquire(void)
   HRESULT res = IDirectInputDevice_Unacquire(kbd_drv_lpDID);
   if (res != DI_OK)
   {
-    kbdDrvDInputFailure("kbdDrvDInputUnacquire(): ", res);
+    kbdDrvDInputFailure("kbdDrvDInputUnacquire():", res);
   }
 }
 
@@ -748,7 +746,7 @@ void kbdDrvDInputAcquire(void)
   HRESULT res = IDirectInputDevice_Acquire(kbd_drv_lpDID); 
   if (res != DI_OK)
   {
-    kbdDrvDInputFailure("kbdDrvDInputAcquire(): ", res);
+    kbdDrvDInputFailure("kbdDrvDInputAcquire():", res);
   }
 }
 
@@ -803,7 +801,7 @@ bool kbdDrvDInputInitialize(void)
   HRESULT res = DirectInput8Create(win_drv_hInstance, DIRECTINPUT_VERSION, IID_IDirectInput8, (void**)&kbd_drv_lpDI, NULL);
   if (res != DI_OK)
   {
-    kbdDrvDInputFailure("kbdDrvDInputInitialize(): DirectInput8Create() ", res );
+    kbdDrvDInputFailure("kbdDrvDInputInitialize(): DirectInput8Create()", res );
     kbd_drv_initialization_failed = true;
     kbdDrvDInputRelease();
     return false;
@@ -814,7 +812,7 @@ bool kbdDrvDInputInitialize(void)
   res = IDirectInput_CreateDevice(kbd_drv_lpDI, GUID_SysKeyboard, &kbd_drv_lpDID, NULL);
   if (res != DI_OK)
   {
-    kbdDrvDInputFailure("kbdDrvDInputInitialize(): CreateDevice() ", res );
+    kbdDrvDInputFailure("kbdDrvDInputInitialize(): CreateDevice()", res );
     kbd_drv_initialization_failed = true;
     kbdDrvDInputRelease();
     return false;
@@ -825,7 +823,7 @@ bool kbdDrvDInputInitialize(void)
   res = IDirectInputDevice_SetDataFormat(kbd_drv_lpDID, &c_dfDIKeyboard);
   if (res != DI_OK)
   {
-    kbdDrvDInputFailure("kbdDrvDInputInitialize(): SetDataFormat() ", res );
+    kbdDrvDInputFailure("kbdDrvDInputInitialize(): SetDataFormat()", res );
     kbd_drv_initialization_failed = true;
     kbdDrvDInputRelease();
     return false;
@@ -855,7 +853,7 @@ bool kbdDrvDInputInitialize(void)
   res = IDirectInputDevice_SetProperty(kbd_drv_lpDID, DIPROP_BUFFERSIZE, &dipdw.diph);
   if (res != DI_OK)
   {
-    kbdDrvDInputFailure("kbdDrvDInputInitialize(): SetProperty() ", res );
+    kbdDrvDInputFailure("kbdDrvDInputInitialize(): SetProperty()", res );
     kbd_drv_initialization_failed = true;
     kbdDrvDInputRelease();
     return false;
@@ -865,7 +863,7 @@ bool kbdDrvDInputInitialize(void)
   res = IDirectInputDevice_SetEventNotification(kbd_drv_lpDID, kbd_drv_DIevent);
   if (res != DI_OK)
   {
-    kbdDrvDInputFailure("kbdDrvDInputInitialize(): SetEventNotification() ", res );
+    kbdDrvDInputFailure("kbdDrvDInputInitialize(): SetEventNotification()", res );
     kbd_drv_initialization_failed = true;
     kbdDrvDInputRelease();
     return false;
@@ -1167,7 +1165,7 @@ void kbdDrvKeypressHandler(void)
   
   if ((res != DI_OK) && (res != DI_BUFFEROVERFLOW))
   {
-    kbdDrvDInputFailure("kbdDrvKeypressHandler(): GetDeviceData() ", res );
+    kbdDrvDInputFailure("kbdDrvKeypressHandler(): GetDeviceData()", res );
   }
   else
   {	

--- a/fellow/SRC/WIN32/C/MOUSEDRV.C
+++ b/fellow/SRC/WIN32/C/MOUSEDRV.C
@@ -116,9 +116,7 @@ STR *mouseDrvDInputErrorString(HRESULT hResult)
 
 void mouseDrvDInputFailure(STR *header, HRESULT err)
 {
-  fellowAddLog(header);
-  fellowAddLog(mouseDrvDInputErrorString(err));
-  fellowAddLog("\n");
+  fellowAddLog("%s %s\n", header, mouseDrvDInputErrorString(err));
 }
 
 
@@ -138,7 +136,7 @@ void mouseDrvDInputAcquire(void)
     {
       if ((res = IDirectInputDevice_Acquire(mouse_drv_lpDID)) != DI_OK)
       {
-        mouseDrvDInputFailure("mouseDrvDInputAcquire(): ", res);
+        mouseDrvDInputFailure("mouseDrvDInputAcquire():", res);
       }
     }
   }
@@ -148,7 +146,7 @@ void mouseDrvDInputAcquire(void)
     {
       if ((res = IDirectInputDevice_Unacquire(mouse_drv_lpDID)) != DI_OK)
       {
-        mouseDrvDInputFailure("mouseDrvDInputUnacquire(): ", res);
+        mouseDrvDInputFailure("mouseDrvDInputUnacquire():", res);
       }
     }
   }
@@ -221,7 +219,7 @@ BOOLE mouseDrvDInputInitialize(void)
   res = DirectInput8Create(win_drv_hInstance, DIRECTINPUT_VERSION, IID_IDirectInput8, (void**)&mouse_drv_lpDI, NULL);
   if (res != DI_OK)
   {
-    mouseDrvDInputFailure("mouseDrvDInputInitialize(): DirectInput8Create() ", res );
+    mouseDrvDInputFailure("mouseDrvDInputInitialize(): DirectInput8Create()", res );
     mouse_drv_initialization_failed = TRUE;
     mouseDrvDInputRelease();
     return FALSE;
@@ -239,7 +237,7 @@ BOOLE mouseDrvDInputInitialize(void)
   res = IDirectInput_CreateDevice(mouse_drv_lpDI, GUID_SysMouse, &mouse_drv_lpDID, NULL);
   if (res != DI_OK)
   {
-    mouseDrvDInputFailure("mouseDrvDInputInitialize(): CreateDevice() ", res );
+    mouseDrvDInputFailure("mouseDrvDInputInitialize(): CreateDevice()", res );
     mouse_drv_initialization_failed = TRUE;
     mouseDrvDInputRelease();
     return FALSE;
@@ -250,7 +248,7 @@ BOOLE mouseDrvDInputInitialize(void)
   res = IDirectInputDevice_SetDataFormat(mouse_drv_lpDID, &c_dfDIMouse);
   if (res != DI_OK)
   {
-    mouseDrvDInputFailure("mouseDrvDInputInitialize(): SetDataFormat() ", res);
+    mouseDrvDInputFailure("mouseDrvDInputInitialize(): SetDataFormat()", res);
     mouse_drv_initialization_failed = TRUE;
     mouseDrvDInputRelease();
     return FALSE;
@@ -260,7 +258,7 @@ BOOLE mouseDrvDInputInitialize(void)
   res = IDirectInputDevice_SetCooperativeLevel(mouse_drv_lpDID, gfxDrvCommon->GetHWND(), DISCL_EXCLUSIVE | DISCL_FOREGROUND);
   if (res != DI_OK)
   {
-    mouseDrvDInputFailure("mouseDrvDInputInitialize(): SetCooperativeLevel() ", res );
+    mouseDrvDInputFailure("mouseDrvDInputInitialize(): SetCooperativeLevel()", res );
     mouse_drv_initialization_failed = TRUE;
     mouseDrvDInputRelease();
     return FALSE;
@@ -280,7 +278,7 @@ BOOLE mouseDrvDInputInitialize(void)
   res = IDirectInputDevice_SetProperty(mouse_drv_lpDID, DIPROP_BUFFERSIZE, &dipdw.diph);
   if (res != DI_OK)
   {
-    mouseDrvDInputFailure("mouseDrvDInputInitialize(): SetProperty() ", res );
+    mouseDrvDInputFailure("mouseDrvDInputInitialize(): SetProperty()", res );
     mouse_drv_initialization_failed = TRUE;
     mouseDrvDInputRelease();
   }
@@ -289,7 +287,7 @@ BOOLE mouseDrvDInputInitialize(void)
   res = IDirectInputDevice_SetEventNotification(mouse_drv_lpDID, mouse_drv_DIevent);
   if (res != DI_OK)
   {
-    mouseDrvDInputFailure("mouseDrvDInputInitialize(): SetEventNotification() ", res );
+    mouseDrvDInputFailure("mouseDrvDInputInitialize(): SetEventNotification()", res );
     mouse_drv_initialization_failed = TRUE;
     mouseDrvDInputRelease();
     return FALSE;
@@ -393,7 +391,7 @@ void mouseDrvMovementHandler(void)
 	
     if (res != DI_OK)
     {
-      mouseDrvDInputFailure("mouseDrvMovementHandler(): GetDeviceData() ", res );
+      mouseDrvDInputFailure("mouseDrvMovementHandler(): GetDeviceData()", res );
     }
     else
     {


### PR DESCRIPTION
fix several instances where log messages were being wrapped in unexpected places because of multi-threaded calls to the logging function