### PR TITLE
Set wait time after event reset to avoid race condition.

### DIFF
--- a/fellow/SRC/WIN32/C/GfxDrvCommon.cpp
+++ b/fellow/SRC/WIN32/C/GfxDrvCommon.cpp
@@ -74,8 +74,8 @@ void GfxDrvCommon::RememberFlipTime()
 
 void GfxDrvCommon::DelayFlipWait(int milliseconds)
 {
-  _wait_for_time = milliseconds;
   ResetEvent(_delay_flip_event);
+  _wait_for_time = milliseconds;
   WaitForSingleObject(_delay_flip_event, INFINITE);
 }
 


### PR DESCRIPTION
Running in an enviromnent with very slow graphics framerate, like a VM might cause a deadlock.