### PR TITLE
Make sure the graphics driver type used is always in sync with current configuration

### DIFF
--- a/fellow/SRC/WinFellow/INCLUDE/Configuration.h
+++ b/fellow/SRC/WinFellow/INCLUDE/Configuration.h
@@ -390,7 +390,7 @@ extern bool cfgGetMeasureSpeed(cfg *config);
 extern void cfgSetDefaults(cfg *config);
 extern BOOLE cfgSetOption(cfg *config, const char *optionstr);
 extern BOOLE cfgSaveOptions(cfg *config, FILE *cfgfile);
-extern bool cfgLoadFromFilename(cfg *, const char *, const bool);
+extern bool cfgLoadFromFilename(cfg *config, const char *filename, const bool bIsPreset);
 extern BOOLE cfgSaveToFilename(cfg *config, const char *filename);
 extern void cfgSynopsis(cfg *config);
 

--- a/fellow/SRC/WinFellow/INCLUDE/GraphicsDriver.h
+++ b/fellow/SRC/WinFellow/INCLUDE/GraphicsDriver.h
@@ -25,7 +25,8 @@ extern void gfxDrvEmulationStop();
 
 extern void gfxDrvNotifyActiveStatus(bool active);
 
-extern bool gfxDrvRestart(DISPLAYDRIVER displaydriver);
+DISPLAYDRIVER gfxDrvTryChangeDisplayDriver(DISPLAYDRIVER newDisplayDriver, bool showErrorMessageBoxes);
+
 extern bool gfxDrvStartup(DISPLAYDRIVER displaydriver);
 extern void gfxDrvShutdown();
 

--- a/fellow/SRC/WinFellow/Windows/GraphicsDriver.cpp
+++ b/fellow/SRC/WinFellow/Windows/GraphicsDriver.cpp
@@ -210,11 +210,11 @@ DISPLAYDRIVER gfxDrvTryChangeDisplayDriver(DISPLAYDRIVER newDisplayDriver, bool 
   {
     if (!gfxDrvDXGIValidateRequirements())
     {
-      _core.Log->AddLog("ERROR: Configuration specified Direct3D 11, but validation of host Direct3d 11 environment failed. Falling back to DirectDraw.\n");
+      _core.Log->AddLog("ERROR: Configuration specified Direct3D 11, but validation of host Direct3D 11 environment failed. Falling back to DirectDraw.\n");
 
       if (showErrorMessageBoxes)
       {
-        fellowShowRequester(FELLOW_REQUESTER_TYPE::FELLOW_REQUESTER_TYPE_ERROR, "Direct3d 11 is required but could not be loaded, falling back to DirectDraw.");
+        fellowShowRequester(FELLOW_REQUESTER_TYPE::FELLOW_REQUESTER_TYPE_ERROR, "Direct3D 11 is required but could not be loaded, falling back to DirectDraw.");
       }
 
       actualDisplayDriver = DISPLAYDRIVER::DISPLAYDRIVER_DIRECTDRAW;
@@ -226,11 +226,11 @@ DISPLAYDRIVER gfxDrvTryChangeDisplayDriver(DISPLAYDRIVER newDisplayDriver, bool 
   if (!result && actualDisplayDriver == DISPLAYDRIVER::DISPLAYDRIVER_DIRECT3D11)
   {
     _core.Log->AddLog(
-        "ERROR: Failed to restart graphics driver for Direct3d 11 even though host environment validation indicated it would be available. Falling back to DirectDraw.\n");
+        "ERROR: Failed to restart graphics driver for Direct3D 11 even though host environment validation indicated it would be available. Falling back to DirectDraw.\n");
 
     if (showErrorMessageBoxes)
     {
-      fellowShowRequester(FELLOW_REQUESTER_TYPE::FELLOW_REQUESTER_TYPE_ERROR, "Failed to initialize Direct3d 11, falling back to DirectDraw.");
+      fellowShowRequester(FELLOW_REQUESTER_TYPE::FELLOW_REQUESTER_TYPE_ERROR, "Failed to initialize Direct3D 11, falling back to DirectDraw.");
     }
 
     actualDisplayDriver = DISPLAYDRIVER::DISPLAYDRIVER_DIRECTDRAW;


### PR DESCRIPTION
Make sure the graphics driver type used is always in sync with current configuration. Mismatch could happen in some situations after load from menu, load from history slot, and cancel changes after editing display settings. Also fixed problem where cancelled diskimage changes were shown on the main dialog.

Closes #131 